### PR TITLE
add clotributor link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # client-pkg
+
+If you are interested in contributing to Knative, take a look at [CLOTRIBUTOR](https://clotributor.dev/search?project=knative&page=1)
+for a list of help wanted issues.


### PR DESCRIPTION
Part of https://github.com/knative/community/issues/1403

Adds a link to the CLOTRIBUTOR page for Knative to the README