### PR TITLE
:wastebasket: Deprecate knative.dev/client-pkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # client-pkg
 
+> [!WARNING]  
+> This module is now deprecated. Please, use [knative.dev/client/pkg](https://pkg.go.dev/knative.dev/client/pkg) instead.
+
 If you are interested in contributing to Knative, take a look at [CLOTRIBUTOR](https://clotributor.dev/search?project=knative&page=1)
 for a list of help wanted issues.

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
+# Deprecated: use knative.dev/client/pkg instead.
 module knative.dev/client-pkg
 
 go 1.22

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-# Deprecated: use knative.dev/client/pkg instead.
+// Deprecated: use knative.dev/client/pkg instead.
 module knative.dev/client-pkg
 
 go 1.22


### PR DESCRIPTION
# Changes

- :wastebasket: Deprecate knative.dev/client-pkg


/kind deprecation

Follows up on https://github.com/knative/client/pull/1953

**Release Note**

```release-note
The knative.dev/client-pkg module is now deprecated. Please, use knative.dev/client/pkg instead.
```
